### PR TITLE
Fix copy-paste typo in generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+- '4'
+- '0.12'
 - '0.11'
 - '0.10'
 script: npm test

--- a/generator.js
+++ b/generator.js
@@ -1,6 +1,6 @@
 module.exports = function*(x0, y0, x1, y1) {
   var dx = x1 - x0;
-  var dy = y1 - x0;
+  var dy = y1 - y0;
   var adx = Math.abs(dx);
   var ady = Math.abs(dy);
   var eps = 0;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/madbence/node-bresenham",
   "devDependencies": {
-    "should": "^3.3.1",
-    "mocha": "^1.18.2"
+    "mocha": "^1.18.2",
+    "semver": "^5.1.0",
+    "should": "^8.1.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,64 @@
 var bresenham = require('../');
 
-describe('Bresenham', function() {
-  it('should call the callback once with one point', function() {
-    var called = 0;
-    bresenham(0, 0, 0, 0, function() { called++; });
-    called.should.equal(1);
+
+/**
+ * Simple function that generates an array of points
+ * starting at (x0, y0). Each successive point increases
+ * by (xDelta, yDelta) until there are length number of points
+ */
+var testLine = function(x0, y0, xDelta, yDelta, length) {
+  var x = x0;
+  var y = y0;
+  var points = [];
+  for(var i = 0; i < length; i++) {
+    points.push({
+      x: x,
+      y: y
+    });
+    x += xDelta;
+    y += yDelta;
+  }
+  return points;
+};
+
+// Make sure our line generating code works
+describe('testLine', function() {
+  it('should create a line increasing along x-axis', function() {
+    var points = testLine(0, 0, 1, 0, 3);
+    points[0].should.deepEqual({x: 0, y: 0});
+    points[1].should.deepEqual({x: 1, y: 0});
+    points[2].should.deepEqual({x: 2, y: 0});
   });
-  it('should call the callback with every point', function() {
-    var called = 0;
-    bresenham(0, 0, 5, 0, function() { called++; });
-    called.should.equal(6);
+  it('should create a line decreasing along y-axis', function() {
+    var points = testLine(0, 0, 0, -1, 3);
+    points[0].should.deepEqual({x: 0, y: 0});
+    points[1].should.deepEqual({x: 0, y: -1});
+    points[2].should.deepEqual({x: 0, y: -2});
   });
 });
+
+var semver = require('semver');
+
+// Testing generator if using at least node v4
+if(semver.gte(process.version, '4.0.0')) {
+  var bresenhamGenerator = require('../generator');
+  
+  describe('Bresenham Generator', function() {
+    it('should generate one point', function() {
+      var points = Array.from(bresenhamGenerator(0, 0, 0, 0));
+      points.length.should.equal(1);
+      points.should.deepEqual(testLine(0, 0, 0, 0, 1));
+    });
+    it('should return correct points for two points of increasing x-values', function() {
+      var points = Array.from(bresenhamGenerator(0, 0, 5, 0));
+      points.length.should.equal(6);
+      points.should.deepEqual(testLine(0, 0, 1, 0, 6));
+    });
+    it('should return correct points for two points of decreasing y-values', function() {
+      var points = Array.from(bresenhamGenerator(0, 5, 0, 0));
+      points.length.should.equal(6);
+      points.should.deepEqual(testLine(0, 5, 0, -1, 6));
+    });
+  });
+
+}


### PR DESCRIPTION
Noticed you fixed a copy-paste typo in `index.js` but forgot to fix `generator.js`. Also added tests to catch this in the future (also added node 4 to travis-ci to test the generator).

Resolves #1
